### PR TITLE
Fix Register button label (was not being updated)

### DIFF
--- a/skipeventconfirmpage.php
+++ b/skipeventconfirmpage.php
@@ -177,12 +177,8 @@ function skipeventconfirmpage_civicrm_buildForm($formName, &$form) {
       if ($changeButtonTitle) {
         $buttons = &$form->getElement('buttons');
         foreach ($buttons->_elements as &$button) {
-          if ($button->_type == 'submit'
-            && in_array(strtolower($button->_attributes['value']), [
-            'review your registration',
-            'continue',
-          ])) {
-            $button->_attributes['value'] = ts('Submit Registration');
+          if ($button->_attributes['type'] == 'submit' && $button->_attributes['name'] == '_qf_Register_upload') {
+            $button->_content = '<i aria-hidden="true" class="crm-i fa-chevron-right"></i> ' . ts('Register');
             break;
           }
         }


### PR DESCRIPTION
On an Event Registration page, the submit button label was not being updated, it kept saying "confirm event registration" (which makes sense for most people anyway, but I found it too long, and the core translation is ambiguous)

This PR fixes to use the same label as core pages, when the confirmation is disabled (just "Register", and with the icon).

![skip](https://user-images.githubusercontent.com/254741/164302209-3875d6df-7978-477a-8eee-603acc312a6b.png)
